### PR TITLE
fix(app-compose): computer to apply optional to spot output

### DIFF
--- a/documentation/src/content/docs/reference/shape/index.mdx
+++ b/documentation/src/content/docs/reference/shape/index.mdx
@@ -7,7 +7,8 @@ tableOfContents: false
 Transforms one or several Spots into a new value. Works inside `run.context`, `enabled.context`, and `createWire.from`.
 
 - `shape<S, T>(spot, fn)` — Returns a `Spot<T>`. `fn` receives the value of `spot`
-- `shape<S, T>(sources, fn)` — Returns a `Spot<T>` from a record or array of Spots. `fn` receives an object or array of their values
+- `shape<S, T>(sources, fn)` — Returns a `Spot<T>` from a record or array of `Spot`s. `fn` receives an object or array of their values
+- `shape<T>(sources)` — Returns a `Spot<T>` without remapping the value of record or array of `Spot`s, only grouping them into one `Spot`.
 
 ```ts
 shape(user.result, (u) => u.name.toUpperCase())
@@ -15,6 +16,8 @@ shape(user.result, (u) => u.name.toUpperCase())
 shape({ first: firstName.result, last: lastName.result }, (v) => `${v.first} ${v.last}`)
 
 shape([firstName.result, lastName.result], ([first, last]) => `${first} ${last}`)
+
+shape({ first: firstName.result, last: lastName.result }) // Spot<{ first: string; last: string }>
 ```
 
 When `shape` fails, the downstream Task skips — the source Task fails, or the callback throws

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grlt-hub/app-compose-dev",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "private": true,
   "homepage": "https://app-compose.dev",
   "license": "MIT",

--- a/packages/app-coda/package.json
+++ b/packages/app-coda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grlt-hub/app-coda",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "private": false,
   "description": "Helper utilities for @grlt-hub/app-compose — reusable building blocks for tasks, wires, and context.",
   "keywords": [

--- a/packages/app-coda/src/debug/__tests__/__snapshots__/mix.test.ts.snap
+++ b/packages/app-coda/src/debug/__tests__/__snapshots__/mix.test.ts.snap
@@ -4,7 +4,7 @@ exports[`debug — mixed targets > renders task + tag + spot together 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",

--- a/packages/app-coda/src/debug/__tests__/__snapshots__/safe.test.ts.snap
+++ b/packages/app-coda/src/debug/__tests__/__snapshots__/safe.test.ts.snap
@@ -4,7 +4,7 @@ exports[`debug — safe > renders healthy spots alongside failing ones 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -38,7 +38,7 @@ exports[`debug — safe > runs the debug task even when a shape spot throws 1`] 
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",

--- a/packages/app-coda/src/debug/__tests__/__snapshots__/spot.test.ts.snap
+++ b/packages/app-coda/src/debug/__tests__/__snapshots__/spot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`debug — spot target > renders a healthy spot alongside one with a mis
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -38,7 +38,7 @@ exports[`debug — spot target > renders a literal spot 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -63,7 +63,7 @@ exports[`debug — spot target > renders a raw task result spot 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -88,7 +88,7 @@ exports[`debug — spot target > renders a shape spot combining multiple sources
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -111,7 +111,7 @@ exports[`debug — spot target > renders a shape spot derived from a single sour
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",

--- a/packages/app-coda/src/debug/__tests__/__snapshots__/tag.test.ts.snap
+++ b/packages/app-coda/src/debug/__tests__/__snapshots__/tag.test.ts.snap
@@ -4,7 +4,7 @@ exports[`debug — tag target > renders a filled tag alongside an unfilled one 1
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -38,7 +38,7 @@ exports[`debug — tag target > renders a filled tag with its value 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -61,7 +61,7 @@ exports[`debug — tag target > renders a tag fed by a task result 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -86,7 +86,7 @@ exports[`debug — tag target > renders an unfilled tag as undefined 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",

--- a/packages/app-coda/src/debug/__tests__/__snapshots__/task.test.ts.snap
+++ b/packages/app-coda/src/debug/__tests__/__snapshots__/task.test.ts.snap
@@ -4,7 +4,7 @@ exports[`debug — task target > renders a done task with status and result 1`] 
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -33,7 +33,7 @@ exports[`debug — task target > renders a failed task with status and error 1`]
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -60,7 +60,7 @@ exports[`debug — task target > renders a healthy task alongside a failing one 
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",
@@ -102,7 +102,7 @@ exports[`debug — task target > renders a skipped task 1`] = `
 [
   [
     "console.groupCollapsed",
-    "[app-coda] debug ",
+    "[app-coda] debug",
   ],
   [
     "console.group",

--- a/packages/app-coda/src/debug/index.ts
+++ b/packages/app-coda/src/debug/index.ts
@@ -7,14 +7,9 @@ type DebugOptions = {
 
 type DebugTarget = Task<unknown> | Tag<unknown> | Spot<unknown>
 
-const safe = <T>(spot: Spot<T>) => optional(shape(spot, (x) => x))
-
 const normalize = (head: DebugOptions | DebugTarget, tail: DebugTarget[]) =>
   !is.task(head) && !is.tag(head) && "name" in head
-    ? {
-        options: head,
-        targets: tail,
-      }
+    ? { options: head, targets: tail }
     : { options: { name: "" }, targets: [head, ...tail] }
 
 function debug(opts: DebugOptions, target: DebugTarget, ...targets: DebugTarget[]): Task<unknown>
@@ -36,10 +31,10 @@ function debug(
         }
       : is.tag(target)
         ? { title: literal(`[Tag]: ${target.name}`), output: optional(target.value) }
-        : { title: literal("[Spot]"), output: safe(target) },
+        : { title: literal("[Spot]"), output: optional(target) },
   )
 
-  const taskName = `${LIBRARY_NAME} debug ${options.name}`
+  const taskName = `${LIBRARY_NAME} debug ${options.name}`.trimEnd()
 
   return createTask({
     name: taskName,

--- a/packages/app-compose/package.json
+++ b/packages/app-compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grlt-hub/app-compose",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "private": false,
   "description": "Lightweight IoC for the front-end — structures your app around isolated tasks, explicit context, and predictable startup.",
   "keywords": [

--- a/packages/app-compose/src/compose/__tests__/runner.test.ts
+++ b/packages/app-compose/src/compose/__tests__/runner.test.ts
@@ -16,7 +16,7 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(undefined)
+      expect(fn).toHaveBeenCalledWith(undefined)
     })
 
     it("void contexts | both", async () => {
@@ -28,8 +28,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(undefined)
-      expect(enabled).toBeCalledWith(undefined)
+      expect(fn).toHaveBeenCalledWith(undefined)
+      expect(enabled).toHaveBeenCalledWith(undefined)
     })
 
     it("simple contexts | run.fn", async () => {
@@ -40,7 +40,7 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith("alpha_api")
+      expect(fn).toHaveBeenCalledWith("alpha_api")
     })
 
     it("simple contexts | enabled.fn", async () => {
@@ -57,8 +57,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(undefined)
-      expect(enabled).toBeCalledWith("alpha_api")
+      expect(fn).toHaveBeenCalledWith(undefined)
+      expect(enabled).toHaveBeenCalledWith("alpha_api")
     })
 
     it("simple contexts | both", async () => {
@@ -75,8 +75,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith("alpha_api")
-      expect(enabled).toBeCalledWith("alpha_api")
+      expect(fn).toHaveBeenCalledWith("alpha_api")
+      expect(enabled).toHaveBeenCalledWith("alpha_api")
     })
 
     it("literal | run.fn", async () => {
@@ -87,7 +87,7 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith("str")
+      expect(fn).toHaveBeenCalledWith("str")
     })
 
     it("literal | enabled.fn", async () => {
@@ -104,8 +104,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(undefined)
-      expect(enabled).toBeCalledWith("str")
+      expect(fn).toHaveBeenCalledWith(undefined)
+      expect(enabled).toHaveBeenCalledWith("str")
     })
 
     it("literal | both", async () => {
@@ -122,8 +122,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(7)
-      expect(enabled).toBeCalledWith("str")
+      expect(fn).toHaveBeenCalledWith(7)
+      expect(enabled).toHaveBeenCalledWith("str")
     })
 
     it("status | run.fn", async () => {
@@ -138,7 +138,7 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith("done")
+      expect(fn).toHaveBeenCalledWith("done")
     })
 
     it("status | enabled.fn", async () => {
@@ -155,8 +155,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(undefined)
-      expect(enabled).toBeCalledWith("done")
+      expect(fn).toHaveBeenCalledWith(undefined)
+      expect(enabled).toHaveBeenCalledWith("done")
     })
 
     it("status | both", async () => {
@@ -188,8 +188,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith({ name: "fail", error })
-      expect(enabled).toBeCalledWith({ name: "done" })
+      expect(fn).toHaveBeenCalledWith({ name: "fail", error })
+      expect(enabled).toHaveBeenCalledWith({ name: "done" })
 
       warn.mockRestore()
     })
@@ -206,7 +206,7 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(undefined)
+      expect(fn).toHaveBeenCalledWith(undefined)
     })
 
     it("optional | enabled.fn", async () => {
@@ -223,8 +223,8 @@ describe("runner", () => {
 
       await run(app[Node$])
 
-      expect(fn).toBeCalledWith(undefined)
-      expect(enabled).toBeCalledWith(undefined)
+      expect(fn).toHaveBeenCalledWith(undefined)
+      expect(enabled).toHaveBeenCalledWith(undefined)
     })
   })
 
@@ -289,7 +289,7 @@ describe("runner", () => {
 
       await run(outer[Node$])
 
-      expect(fn).toBeCalledWith("alpha_api")
+      expect(fn).toHaveBeenCalledWith("alpha_api")
     })
   })
 })

--- a/packages/app-compose/src/computable/__tests__/lens.test.ts
+++ b/packages/app-compose/src/computable/__tests__/lens.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest"
+import { createComputer } from "../computer"
+import { Missing$, type SpotInternal } from "../definition"
+import { optional } from "../optional"
 import { reference } from "../reference"
 
 describe("lens", () => {
@@ -10,5 +13,42 @@ describe("lens", () => {
 
     // @ts-expect-error: x.a readonly by type, checking runtime error
     expect(() => (x.a = a)).toThrow("Modifying a Reference is not allowed.")
+  })
+
+  it("propagates Missing$ through a non-optional lensed read", () => {
+    const key = Symbol()
+
+    const registry = new Map<symbol, unknown>().set(key, Missing$)
+    const { compute } = createComputer(registry)
+
+    const spot = reference.lensed<{ a: { b: number } }>(key).a.b as SpotInternal
+
+    const result = compute(spot)
+    expect(result).toStrictEqual(Missing$)
+  })
+
+  it("coerces Missing$ to undefined of an optional lensed read", () => {
+    const key = Symbol()
+
+    const registry = new Map<symbol, unknown>().set(key, Missing$)
+    const { compute } = createComputer(registry)
+
+    const spot = reference.lensed<{ a: { b: number } }>(key).a.b
+    const mapped = optional(spot) as SpotInternal
+
+    const result = compute(mapped)
+    expect(result).toBeUndefined()
+  })
+
+  it("reads through a present lensed source", () => {
+    const key = Symbol()
+
+    const registry = new Map<symbol, unknown>().set(key, { a: { b: 7 } })
+    const { compute } = createComputer(registry)
+
+    const spot = reference.lensed<{ a: { b: number } }>(key).a.b as SpotInternal
+
+    const result = compute(spot)
+    expect(result).toStrictEqual(7)
   })
 })

--- a/packages/app-compose/src/computable/__tests__/optional.test.ts
+++ b/packages/app-compose/src/computable/__tests__/optional.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { createComputer } from "../computer"
 import { Optional$, type SpotInternal } from "../definition"
 import { optional } from "../optional"
 import { reference } from "../reference"
+import { shape } from "../shape"
 
 describe("optional", () => {
   it("marks spot as optional", () => {
@@ -12,7 +13,7 @@ describe("optional", () => {
     expect(target[Optional$]).toBe(true)
   })
 
-  it("replaces missing value with undefined during compute", () => {
+  it("coerces a missing input value to undefined", () => {
     const map = new Map<symbol, unknown>()
     const { compute } = createComputer(map)
 
@@ -22,6 +23,24 @@ describe("optional", () => {
 
     const result = compute(target as SpotInternal)
 
+    expect(result).toBeUndefined()
+  })
+
+  it("coerces a missing mapped value to undefined", () => {
+    const symbol = Symbol()
+    const map = new Map<symbol, unknown>().set(symbol, 42)
+
+    const raise = vi.fn().mockThrowOnce(new Error("test"))
+
+    const { compute } = createComputer(map)
+
+    const source = reference<number>(symbol)
+    const mapped = shape(source, raise)
+    const target = optional(mapped)
+
+    const result = compute(target as SpotInternal)
+
+    expect(raise).toHaveBeenCalledWith(42)
     expect(result).toBeUndefined()
   })
 })

--- a/packages/app-compose/src/computable/__tests__/shape.test-d.ts
+++ b/packages/app-compose/src/computable/__tests__/shape.test-d.ts
@@ -1,0 +1,26 @@
+import { describe, expectTypeOf, test } from "vitest"
+import type { Spot } from "../definition"
+import { literal } from "../literal"
+import { reference } from "../reference"
+import { shape } from "../shape"
+
+describe("shape", () => {
+  describe("no-fn overload", () => {
+    test("maps single spot -> Spot of its value", () => {
+      const result = shape(literal<number>(1))
+      expectTypeOf(result).toEqualTypeOf<Spot<number>>()
+    })
+
+    test("builds record of spots -> Spot<record>", () => {
+      const result = shape({ a: literal<number>(1), b: reference<string>(Symbol()) })
+
+      expectTypeOf(result).toEqualTypeOf<Spot<{ a: number; b: string }>>()
+    })
+
+    test("builds tuple of spots -> Spot<tuple>", () => {
+      const result = shape([literal(1), reference<string>(Symbol())] as const)
+
+      expectTypeOf(result).toEqualTypeOf<Spot<readonly [1, string]>>()
+    })
+  })
+})

--- a/packages/app-compose/src/computable/__tests__/shape.test.ts
+++ b/packages/app-compose/src/computable/__tests__/shape.test.ts
@@ -8,7 +8,7 @@ const registry = new Map<symbol, unknown>()
 const { compute } = createComputer(registry)
 
 describe("shape", () => {
-  it("maps spot -> spot", () => {
+  it("maps spot + fn -> spot", () => {
     const source = literal<string>("test")
     const target = shape(source, (x) => x.length)
 
@@ -17,13 +17,27 @@ describe("shape", () => {
     expect(result).toBe(4)
   })
 
-  it("maps shape -> spot", () => {
+  it("maps shape + fn -> spot", () => {
     const source = literal<string>("test")
     const target = shape({ a: source }, ({ a }) => a.length)
 
     const result = compute(target as SpotInternal)
 
     expect(result).toBe(4)
+  })
+
+  it("maps spot -> spot", () => {
+    const source = shape(literal(42))
+    const result = compute(source as SpotInternal)
+
+    expect(result).toBe(42)
+  })
+
+  it("maps shape -> spot", () => {
+    const source = shape({ a: literal(42), b: literal("other") })
+    const result = compute(source as SpotInternal)
+
+    expect(result).toStrictEqual({ a: 42, b: "other" })
   })
 
   it("catches userland errors", () => {
@@ -41,7 +55,6 @@ describe("shape", () => {
     const fn = vi.fn((x: unknown) => x)
     const value = shape(literal(0), fn) as SpotInternal
 
-    // note: unrealistic, computer does not run `fn` if `build` is missing
     value[Compute$].unshift(() => Missing$)
 
     const result = compute(value as SpotInternal)

--- a/packages/app-compose/src/computable/computer.ts
+++ b/packages/app-compose/src/computable/computer.ts
@@ -33,15 +33,14 @@ const createComputer = (registry: Map<symbol, unknown>): Computer => {
    * Resolves the spot's underlying value (`Build$`, `Literal$`, or `Read$`),
    * then applies all `Compute$` transformations in order.
    *
-   * `Missing$` propagation rules:
-   *  - If resolved value is `Missing$` and spot is non-`Optional$`, return `Missing$`
-   *    (propagates incompleteness up the chain)
-   *  - If resolved value is `Missing$` and spot is `Optional$`, substitute undefined
-   *    and continue through `Compute$` normally
-   *  - Otherwise, resolved value passes through `Compute$` as-is
+   * `Missing$` flow is three-step `read -> compute -> optional`
+   *
+   * 1. Read `source` value (either literal, built, or from registry) as-is
+   * 2. Map the `source` value through the `Compute$` pipeline, preserving `Missing$` and delegating to internal-land
+   * 3. Guard `Missing$` according to `Optional$`, coercing to `undefined` if optional, or propagating as-is if not
    *
    * @param spot The `Spot` to evaluate
-   * @returns The resolved value or `Missing$` if resolution failed
+   * @returns The resolved value, or `Missing$` when non-optional spot resolution fails
    */
   const compute = <T = unknown>(spot: SpotInternal<T>): T | typeof Missing$ => {
     let resolved: unknown
@@ -51,13 +50,10 @@ const createComputer = (registry: Map<symbol, unknown>): Computer => {
     else if (Read$ in spot) resolved = registry.has(spot[Read$]) ? registry.get(spot[Read$]) : Missing$
     else throw /* unknown unit */ new Error(`${LIBRARY_NAME} Invalid Unit.`)
 
-    if (resolved === Missing$)
-      if (!spot[Optional$]) return Missing$
-      else resolved = undefined
-
     for (const step of spot[Compute$]) resolved = step(resolved)
 
-    return resolved as T
+    if (resolved === Missing$ && spot[Optional$]) return undefined as T
+    else return resolved as T
   }
 
   const computeSafe = <T = unknown>(spot: SpotInternal<T>): T | undefined => {

--- a/packages/app-compose/src/computable/lens.ts
+++ b/packages/app-compose/src/computable/lens.ts
@@ -1,5 +1,5 @@
 import { LIBRARY_NAME } from "@shared"
-import { Compute$, type SpotInternal } from "./definition"
+import { Compute$, Missing$, type SpotInternal } from "./definition"
 
 const Self$ = Symbol(/* internal */)
 
@@ -7,9 +7,11 @@ const raise = () => {
   throw new Error(`${LIBRARY_NAME} Modifying a Reference is not allowed.`)
 }
 
+const reader = (property: string) => (value: any) => (value === Missing$ ? Missing$ : value?.[property])
+
 const get: ProxyHandler<SpotInternal>["get"] = (target, property, recv) =>
   typeof property === "string"
-    ? proxy({ ...target, [Compute$]: target[Compute$].concat((value: any) => value?.[property]) })
+    ? proxy({ ...target, [Compute$]: target[Compute$].concat(reader(property)) })
     : property === Self$
       ? target
       : Reflect.get(target, property, recv)

--- a/packages/app-compose/src/computable/optional.ts
+++ b/packages/app-compose/src/computable/optional.ts
@@ -1,6 +1,9 @@
 import { Optional$, type Spot, type SpotInternal } from "./definition"
 import { proxy } from "./lens"
 
+/**
+ * Mark a `Spot` as optional.
+ */
 const optional = <T>(spot: Spot<T>): Spot<T | undefined> => {
   const self = proxy.self(spot as SpotInternal<T>)
   const updated: SpotInternal<T | undefined> = { ...self, [Optional$]: true }

--- a/packages/app-compose/src/computable/shape.ts
+++ b/packages/app-compose/src/computable/shape.ts
@@ -2,7 +2,7 @@ import type { ContextToSpot } from "./context"
 import { build } from "./build"
 import { Compute$, Missing$, type ComputeStep, type Spot } from "./definition"
 
-const wrap =
+const safe =
   <Fn extends (value: any) => any>(fn: Fn): ComputeStep =>
   (value) => {
     try {
@@ -14,12 +14,13 @@ const wrap =
 
 function shape<S, T>(spot: Spot<S>, fn: (from: S) => T): Spot<T>
 
+function shape<T>(ctx: ContextToSpot<T>): Spot<T>
 function shape<S, T>(ctx: ContextToSpot<S>, fn: (from: NoInfer<S>) => T): Spot<T>
 
-function shape<S, T>(ctxOrSpot: ContextToSpot<S> | Spot<S>, fn: (from: NoInfer<S>) => T): Spot<T> {
+function shape<S, T>(ctxOrSpot: ContextToSpot<S> | Spot<S>, fn?: (from: NoInfer<S>) => T): Spot<T> {
   const spot = build<S>(ctxOrSpot)
 
-  spot[Compute$].push(wrap(fn))
+  if (fn) spot[Compute$].push(safe(fn))
 
   return spot as Spot<T>
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grlt-hub/eslint-plugin-app-compose",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "private": false,
   "description": "Enforcing best practices for @grlt-hub/app-compose",
   "keywords": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,14 +2,15 @@ packages:
   - packages/*
   - documentation
 
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  workerd: true
+
 ignoredBuiltDependencies:
   - sharp
 
 minimumReleaseAge: 4320
-
-allowBuilds:
-  "esbuild": true
-  "lefthook": true
 
 patchedDependencies:
   starlight-llms-txt: patches/starlight-llms-txt.patch


### PR DESCRIPTION
Update `Computer` behavior to apply `Optional$` to `Spot` output (after `Compute$`) instead of `Spot` input. This now properly exposes `Missing$` to mappers that can freely override it, allowing for extra operators like `default`.