### PR TITLE
fix(docs): make llms-full.txt respect the exclude list

### DIFF
--- a/documentation/astro.config.mjs
+++ b/documentation/astro.config.mjs
@@ -130,7 +130,7 @@ export default defineConfig({
       plugins: [
         starlightLlmsTxt({
           rawContent: false,
-          exclude: ["sandbox", "privacy"],
+          exclude: ["sandbox", "privacy", "404"],
           customSets: [
             {
               label: "App-Coda",

--- a/patches/starlight-llms-txt.patch
+++ b/patches/starlight-llms-txt.patch
@@ -1,5 +1,5 @@
 diff --git a/entryToSimpleMarkdown.ts b/entryToSimpleMarkdown.ts
-index d0ce19a6abed550fe3a4eb09fa186815055daa15..72cb36ed1149cd58bea92c1368299d2b3e23931b 100644
+index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..e993ad1c3e90e96d5b39dec590aa870c1a5d1737 100644
 --- a/entryToSimpleMarkdown.ts
 +++ b/entryToSimpleMarkdown.ts
 @@ -29,7 +29,7 @@ const selectors = [...minify.customSelectors];
@@ -11,3 +11,21 @@ index d0ce19a6abed550fe3a4eb09fa186815055daa15..72cb36ed1149cd58bea92c1368299d2b
  });
  
  const htmlToMarkdownPipeline = unified()
+diff --git a/llms-full.txt.ts b/llms-full.txt.ts
+index 03f408bf7106a64f1730c381d422ac4a911aeea9..9907aed55358cab7e652991f2946a6e4ecbbccde 100644
+--- a/llms-full.txt.ts
++++ b/llms-full.txt.ts
+@@ -1,4 +1,5 @@
+ import type { APIRoute } from 'astro';
++import { starlightLllmsTxtContext } from 'virtual:starlight-llms-txt/context';
+ import { generateLlmsTxt } from './generator';
+ import { getSiteTitle } from './utils';
+ 
+@@ -13,6 +14,7 @@ export const GET: APIRoute = async (context) => {
+ 	const body = await generateLlmsTxt(context, {
+ 		minify: false,
+ 		description: `This is the full developer documentation for ${getSiteTitle()}`,
++		exclude: starlightLllmsTxtContext.exclude,
+ 	});
+ 	return new Response(body);
+ };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   starlight-llms-txt:
-    hash: 859ca4060cee3297c58ab0f6542d60a74417084392ffb2c53f1cda3c3fe22b70
+    hash: bf2c5450cd33996d6db51bcab7f276c17d1a2e91b5dfbd7c045ad5624179a648
     path: patches/starlight-llms-txt.patch
 
 importers:
@@ -87,7 +87,7 @@ importers:
         version: 0.24.0(@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))
       starlight-llms-txt:
         specifier: 0.8.1
-        version: 0.8.1(patch_hash=859ca4060cee3297c58ab0f6542d60a74417084392ffb2c53f1cda3c3fe22b70)(@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))
+        version: 0.8.1(patch_hash=bf2c5450cd33996d6db51bcab7f276c17d1a2e91b5dfbd7c045ad5624179a648)(@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 4.20260526.1
@@ -8209,7 +8209,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  starlight-llms-txt@0.8.1(patch_hash=859ca4060cee3297c58ab0f6542d60a74417084392ffb2c53f1cda3c3fe22b70)(@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)):
+  starlight-llms-txt@0.8.1(patch_hash=bf2c5450cd33996d6db51bcab7f276c17d1a2e91b5dfbd7c045ad5624179a648)(@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@astrojs/mdx': 5.0.4(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))
       '@astrojs/starlight': 0.39.2(astro@6.3.3(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3)


### PR DESCRIPTION
## Problem

A fresh AI agent ingesting `/llms-full.txt` reported that the file opens with the **404 page content** ("Page not found") before the real documentation. The `starlight-llms-txt` plugin applies the `exclude` option only to `llms-small.txt` — `llms-full.txt` includes every page in the docs collection unconditionally.

## Fix

Extend our existing pnpm patch for `starlight-llms-txt`: `llms-full.txt.ts` now passes the user-configured `exclude` (already available in the plugin's virtual context — `llms-small.txt.ts` uses it the same way) to the generator, and `404` is added to the exclude list in `astro.config.mjs`.

## Result

`llms-full.txt` now opens with `# Overview` and contains 35 doc sections — the 404 stub, the sandbox shell page, and the privacy page (not library docs) are out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)