### PR TITLE
ci: bump pages actions to v5 for node24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: pnpm --filter ./documentation build
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: documentation/dist
 
@@ -78,4 +78,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## What

GitHub Actions annotations on every docs deploy warn that `actions/upload-artifact@v4` (pulled in by `upload-pages-artifact@v3`) and `actions/deploy-pages@v4` run on the deprecated Node.js 20 runtime.

- `actions/upload-pages-artifact`: `v3` → `v5.0.0` (SHA-pinned, matching the style of the other actions in this workflow)
- `actions/deploy-pages`: `v4` → `v5.0.0` (SHA-pinned)

Both v5 majors run on Node 24; the action interfaces are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)