### PR TITLE
fix(ci): include hidden files in pages artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: documentation/dist
+          # v5 strips dotfiles by default; keep .well-known/security.txt in the artifact
+          include-hidden-files: true
 
   deploy-docs:
     needs: build-docs


### PR DESCRIPTION
## Problem

The v5 bump of `upload-pages-artifact` (#120) silently dropped `/.well-known/security.txt` from the deployed site (now 404). Unlike v3, v5 adds `--exclude=.[^/]*` to its tar call unless told otherwise — verified by downloading the latest pages artifact: zero `well-known` entries in `artifact.tar`.

## Fix

Set the action's `include-hidden-files: true` input (it still excludes `.git`/`.github` regardless).

Caught by the post-deploy smoke run; everything else in the smoke suite was green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)