### PR TITLE
docs: toc heading polish and llms.txt landing positioning

### DIFF
--- a/documentation/astro.config.mjs
+++ b/documentation/astro.config.mjs
@@ -132,6 +132,22 @@ export default defineConfig({
       plugins: [
         starlightLlmsTxt({
           rawContent: false,
+          // the landing page is a splash template and never lands in the
+          // generated files — carry its positioning over by hand, verbatim
+          description: "Lightweight IoC for the front-end. Compose apps you can control and trust.",
+          details: [
+            "App-Compose is a small TypeScript library for composing apps from independent pieces. Features, services, and modules often know about each other directly. That makes them hard to test, reuse, and maintain. With App-Compose, each part declares what it needs, and you supply it — so you stay in control as your app grows.",
+            "",
+            "What you get:",
+            "",
+            "- **Simplicity** — A small API with zero dependencies: lightweight, no containers, providers, or decorators. Framework-agnostic.",
+            "- **Clarity** — No magic, no globals. Context moves through clear, typed wiring. Your app runs exactly as you composed it.",
+            "- **Reusability** — Same code, different context per compose. Reuse across apps, tests, and environments — no copy-paste.",
+            "- **Testability** — Validate your composition in tests. Missing context, duplicates, and unused wires fail in CI — not at startup.",
+            "- **Observability** — Inspect your app as plain JSON — log it, render it, diff it across environments. Hook into start, complete, and fail events for timing, logs, or traces.",
+            "",
+            "If you want to use App-Compose for a part of your existing app, you don't have to rewrite the rest. Add it to your stack, and bring in more when you're ready.",
+          ].join("\n"),
           exclude: ["sandbox", "privacy", "404"],
           customSets: [
             {

--- a/documentation/src/styles/custom.css
+++ b/documentation/src/styles/custom.css
@@ -664,10 +664,12 @@ body:has(.hero) .sl-markdown-content > * + .sl-heading-wrapper.level-h2 {
   color: var(--sl-color-gray-3);
 }
 
-/* the "On this page" heading matches the sidebar group openers */
+/* the "On this page" heading: group-opener metrics, but neutral — the same
+   gray as the links it holds */
 .right-sidebar .right-sidebar-panel h2 {
   font-size: var(--sl-text-base);
   font-weight: 500;
+  color: var(--sl-color-gray-3);
 }
 
 /* current page: accent text only (Starlight default paints an accent pill) */

--- a/documentation/src/styles/custom.css
+++ b/documentation/src/styles/custom.css
@@ -665,11 +665,13 @@ body:has(.hero) .sl-markdown-content > * + .sl-heading-wrapper.level-h2 {
 }
 
 /* the "On this page" heading: group-opener metrics, but neutral — the same
-   gray as the links it holds */
+   gray as the links it holds; indented by the links' --pad-inline (0.5rem)
+   so it left-aligns with them */
 .right-sidebar .right-sidebar-panel h2 {
   font-size: var(--sl-text-base);
   font-weight: 500;
   color: var(--sl-color-gray-3);
+  padding-inline-start: 0.5rem;
 }
 
 /* current page: accent text only (Starlight default paints an accent pill) */


### PR DESCRIPTION
Two small follow-ups to #122 in one PR.

## Table of contents
- the "On this page" heading drops to the same gray as the links it holds (group-opener metrics kept: 500 / 16px)
- indented by the links' inline inset so it left-aligns with them

## llms.txt
The landing page (`home/index.mdx`) is a splash template, so none of its copy reaches the generated `llms*.txt` files — an LLM reading them never saw the brand positioning. Carried over via `starlight-llms-txt`'s own `description` / `details` options, verbatim from the landing:

- blockquote: "Lightweight IoC for the front-end. Compose apps you can control and trust."
- the "What it's for" lead paragraph
- the five value cards (Simplicity / Clarity / Reusability / Testability / Observability)
- the incremental-adoption line

## Verification
Built site checked with Playwright (computed colors and alignment asserted); `dist/llms.txt` opens with the full positioning block, doc sets unchanged below. `pnpm build` + links validator green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)