### PR TITLE
refactor(app-coda): drop identity fn from debug task output shape

### DIFF
--- a/packages/app-coda/src/debug/index.ts
+++ b/packages/app-coda/src/debug/index.ts
@@ -24,10 +24,11 @@ function debug(
     is.task(target)
       ? {
           title: literal(`[Task]: ${target.name}`),
-          output: shape(
-            { status: optional(target.status), result: optional(target.result), error: optional(target.error) },
-            (x) => x,
-          ),
+          output: shape({
+            status: optional(target.status),
+            result: optional(target.result),
+            error: optional(target.error),
+          }),
         }
       : is.tag(target)
         ? { title: literal(`[Tag]: ${target.name}`), output: optional(target.value) }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -59,11 +59,13 @@
   },
   "dependencies": {
     "@typescript-eslint/type-utils": "^8.60.0",
-    "@typescript-eslint/utils": "^8.60.0"
+    "@typescript-eslint/utils": "^8.60.0",
+    "esquery": "^1.7.0"
   },
   "devDependencies": {
     "@grlt-hub/app-coda": "workspace:*",
     "@grlt-hub/app-compose": "workspace:*",
+    "@types/esquery": "1.5.4",
     "@typescript-eslint/rule-tester": "8.60.0",
     "eslint": "10.4.1"
   },

--- a/packages/eslint-plugin/src/rules/task-options-order/task-options-order.test.ts
+++ b/packages/eslint-plugin/src/rules/task-options-order/task-options-order.test.ts
@@ -88,6 +88,33 @@ ruleTester.run("task-options-order", rule, {
         createTask(factory({ name: 'alpha' }))
       `,
     },
+    {
+      name: "leading spread, known keys already ordered after it",
+      code: ts`
+        ${commonCode}
+
+        const base = {};
+        createTask({ ...base, name: 'alpha', run })
+      `,
+    },
+    {
+      name: "trailing spread, known keys already ordered before it",
+      code: ts`
+        ${commonCode}
+
+        const rest = {};
+        createTask({ name: 'alpha', run, ...rest })
+      `,
+    },
+    {
+      name: "spread between known keys — order undeterminable, not reported",
+      code: ts`
+        ${commonCode}
+
+        const mid = {};
+        createTask({ run, ...mid, name: 'alpha' })
+      `,
+    },
   ],
   invalid: [
     {
@@ -294,6 +321,79 @@ ruleTester.run("task-options-order", rule, {
       `,
       output: null,
       errors: [{ messageId: "invalidOrder" }],
+    },
+    {
+      name: "leading spread — known keys after it are reordered, spread stays first",
+      code: ts`
+        ${commonCode}
+
+        const base = {};
+        createTask({ ...base, run, name: 'alpha' })
+      `,
+      output: ts`
+        ${commonCode}
+
+        const base = {};
+        createTask({
+        ...base,
+        name: 'alpha',
+        run
+        })
+      `,
+      errors: [
+        {
+          messageId: "invalidOrder",
+          data: { correctOrder: "name -> run", currentOrder: "run -> name" },
+        },
+      ],
+    },
+    {
+      name: "trailing spread — known keys before it are reordered, spread stays last",
+      code: ts`
+        ${commonCode}
+
+        const rest = {};
+        createTask({ run, name: 'alpha', ...rest })
+      `,
+      output: ts`
+        ${commonCode}
+
+        const rest = {};
+        createTask({
+        name: 'alpha',
+        run,
+        ...rest
+        })
+      `,
+      errors: [
+        {
+          messageId: "invalidOrder",
+          data: { correctOrder: "name -> run", currentOrder: "run -> name" },
+        },
+      ],
+    },
+    {
+      name: "unknown key is moved to the end, known keys sorted",
+      code: ts`
+        ${commonCode}
+
+        createTask({ foo: 1, run, name: 'alpha' })
+      `,
+      output: ts`
+        ${commonCode}
+
+        createTask({
+        name: 'alpha',
+        run,
+        foo: 1
+        })
+      `,
+      errors: [
+        {
+          messageId: "invalidOrder",
+          data: { correctOrder: "name -> run -> foo", currentOrder: "foo -> run -> name" },
+        },
+      ],
     },
   ],
 })

--- a/packages/eslint-plugin/src/rules/task-options-order/task-options-order.test.ts
+++ b/packages/eslint-plugin/src/rules/task-options-order/task-options-order.test.ts
@@ -71,6 +71,23 @@ ruleTester.run("task-options-order", rule, {
         })
       `,
     },
+    {
+      name: "shorthand run and enabled are left untouched",
+      code: ts`
+        ${commonCode}
+
+        createTask({ name: 'alpha', run, enabled })
+      `,
+    },
+    {
+      name: "argument is a factory call, not an object literal",
+      code: ts`
+        ${commonCode}
+
+        declare const factory: (opts: { name: string }) => Parameters<typeof createTask>[0];
+        createTask(factory({ name: 'alpha' }))
+      `,
+    },
   ],
   invalid: [
     {
@@ -220,6 +237,63 @@ ruleTester.run("task-options-order", rule, {
           },
         },
       ],
+    },
+    {
+      name: "misordered shorthand run is reordered, shorthand preserved",
+      code: ts`
+        ${commonCode}
+
+        createTask({ run, name: 'alpha' })
+      `,
+      output: ts`
+        ${commonCode}
+
+        createTask({
+        name: 'alpha',
+        run
+        })
+      `,
+      errors: [
+        {
+          messageId: "invalidOrder",
+          data: { correctOrder: "name -> run", currentOrder: "run -> name" },
+        },
+      ],
+    },
+    {
+      name: "misordered config with a spread in run — top level reordered, spread preserved",
+      code: ts`
+        ${commonCode}
+
+        const base = { context: literal('0') };
+        createTask({ run: { ...base, fn: run }, name: 'alpha' })
+      `,
+      output: ts`
+        ${commonCode}
+
+        const base = { context: literal('0') };
+        createTask({
+        name: 'alpha',
+        run: { ...base, fn: run }
+        })
+      `,
+      errors: [
+        {
+          messageId: "invalidOrder",
+          data: { correctOrder: "name -> run.fn", currentOrder: "run.fn -> name" },
+        },
+      ],
+    },
+    {
+      name: "nested key would cross a spread — reported, but not autofixed",
+      code: ts`
+        ${commonCode}
+
+        const base = { fn: run };
+        createTask({ run: { fn: run, ...base, context: literal('0') }, name: 'alpha' })
+      `,
+      output: null,
+      errors: [{ messageId: "invalidOrder" }],
     },
   ],
 })

--- a/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
+++ b/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
@@ -116,19 +116,15 @@ const isOrdered = (keys: string[]) => {
 // at the head (-Infinity) or tail (Infinity); an unknown key sorts to the end (Infinity); an inline
 // `run`/`enabled` is rebuilt recursively (null if its own keys would cross a spread); the rest is
 // emitted verbatim, so shorthand and comments survive.
-const entryOf = ({
-  prop,
-  index,
-  props,
-  group,
-  source,
-}: {
+type EntryOfParams = {
   prop: Element
   index: number
   props: Element[]
   group: string | null
   source: Readonly<TSESLint.SourceCode>
-}): Entry | null => {
+}
+
+const entryOf = ({ prop, index, props, group, source }: EntryOfParams): Entry | null => {
   if (isSpread(prop)) {
     if (isTrailingSpread(props, index)) return { rank: Infinity, text: source.getText(prop) }
     if (isLeadingSpread(props, index)) return { rank: -Infinity, text: source.getText(prop) }

--- a/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
+++ b/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
@@ -8,13 +8,24 @@ const GROUPS = [
   { key: "enabled", nested: ["context", "fn"] } as const,
 ]
 
-const TRUE_ORDER = GROUPS.flatMap((group) => (group.nested ? group.nested.map((n) => `${group.key}.${n}`) : group.key))
+// Canonical rank of every key — top-level groups and their nested keys. A `run`/`enabled` that is
+// opaque (shorthand, variable, …) ranks at its group position; an inline one ranks at the leaf level.
+// A config holds one or the other, never both, so the two never collide.
+const RANK = new Map<string, number>()
+GROUPS.forEach((group, groupIndex) => {
+  RANK.set(group.key, groupIndex * 10)
+  group.nested?.forEach((nested, nestedIndex) => RANK.set(`${group.key}.${nested}`, groupIndex * 10 + nestedIndex + 1))
+})
+const rankOf = (key: string) => RANK.get(key) ?? Infinity
+
+const TOP_KEYS = new Set<string>(GROUPS.map((group) => group.key))
+const NESTED_KEYS = new Set<string>(GROUPS.flatMap((group) => group.nested ?? []))
+const NESTED_ORDER = GROUPS.find((group) => group.nested)?.nested ?? []
 
 const importSelector = `ImportDeclaration[source.value=${PACKAGE_NAME.CORE}]`
 const methodSelector = `ImportSpecifier[imported.name=${UNITS.CREATE_TASK}]`
 
 const callSelector = `[callee.type="Identifier"][arguments.length=1]`
-const argumentSelector = `ObjectExpression.arguments`
 
 export default createRule({
   name: "task-options-order",
@@ -35,67 +46,110 @@ export default createRule({
     const source = context.sourceCode
     const imports = new Set<string>()
 
-    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.ObjectExpression] }
+    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.CallExpressionArgument] }
 
     return {
       [`${importSelector} > ${methodSelector}`]: (node: Node.ImportSpecifier) => void imports.add(node.local.name),
 
-      [`CallExpression${callSelector}:has(${argumentSelector})`]: (node: MethodCall) => {
+      [`CallExpression${callSelector}`]: (node: MethodCall) => {
         if (!imports.has(node.callee.name)) return
 
         const [config] = node.arguments
+        // Bail only when the order is genuinely undeterminable (non-object arg, or a top-level spread /
+        // computed / getter / unknown key — anything that hides where the real options sit).
+        if (config.type !== NodeType.ObjectExpression || !hasKnownShape(config)) return
 
-        const hasWeirdProperty = config.properties.some(
-          (prop) => prop.type === NodeType.SpreadElement || prop.key.type !== NodeType.Identifier,
-        )
-        if (hasWeirdProperty) return
+        const keys = currentKeys(config.properties as TopProperty[])
+        if (isCorrectOrder(keys)) return
 
-        const properties = config.properties as (Node.Property & { key: Node.Identifier })[]
-        const current = getCurrentKeys(properties)
+        const correctOrder = [...keys].sort((a, b) => rankOf(a) - rankOf(b)).join(" -> ")
+        const data = { correctOrder, currentOrder: keys.join(" -> ") }
 
-        if (isCorrectOrder(current.keys)) return
+        // Reorder by relocating the real property nodes, so shorthand/spread/comments survive. Attach the
+        // fix only when it fully resolves the violation; if a nested key would have to move across a spread
+        // (where position is semantically load-bearing), report it but leave the code for a human.
+        if (isFullyFixable(config)) {
+          context.report({
+            node: config,
+            messageId: "invalidOrder",
+            data,
+            fix: (fixer) => [fixer.replaceText(config, reorder(config, source))],
+          })
+          return
+        }
 
-        const correctOrder = TRUE_ORDER.filter((item) => current.keys.includes(item))
-        const snippets = buildSnippets({ source, nodes: current.nodes })
-
-        const data = { correctOrder: correctOrder.join(" -> "), currentOrder: current.keys.join(" -> ") }
-        context.report({
-          node: config,
-          messageId: "invalidOrder",
-          data,
-          fix: (fixer) => [fixer.replaceText(config, `{\n${snippets.join(`,\n`)}\n}`)],
-        })
+        context.report({ node: config, messageId: "invalidOrder", data })
       },
     }
   },
 })
 
-const getCurrentKeys = (properties: (Node.Property & { key: Node.Identifier })[]) => {
-  const nodes = new Map<string, Node.Property>()
+type TopProperty = Node.Property & { key: Node.Identifier }
+
+// A plain `key: value` (or shorthand) property — the only shape we relocate/rebuild by name.
+// Spreads, getters/setters, methods and computed keys are not plain props.
+const isPlainProp = (prop: Node.ObjectLiteralElement): prop is Node.Property & { key: Node.Identifier } =>
+  prop.type === NodeType.Property &&
+  prop.kind === "init" &&
+  !prop.method &&
+  !prop.computed &&
+  prop.key.type === NodeType.Identifier
+
+// The order is determinable when every top-level entry is a plain, known key. A spread / computed /
+// getter / unknown key hides where the real options sit, so we can't reason about order at all.
+const hasKnownShape = (config: Node.ObjectExpression) =>
+  config.properties.every((prop) => isPlainProp(prop) && TOP_KEYS.has(prop.key.name))
+
+const isRunGroup = (name: string) => name === "run" || name === "enabled"
+
+// A `run`/`enabled` object we can rebuild key-by-key: only plain, known nested keys (no spread/unknown).
+const isReconstructable = (obj: Node.ObjectExpression) =>
+  obj.properties.every((p) => isPlainProp(p) && NESTED_KEYS.has(p.key.name))
+
+// Are the visible nested keys already in canonical order? (Used for objects we can't rebuild.)
+const isNestedOrdered = (group: string, obj: Node.ObjectExpression) => {
+  let seen = -1
+  for (const p of obj.properties) {
+    if (!isPlainProp(p) || !NESTED_KEYS.has(p.key.name)) continue
+    const placement = rankOf(`${group}.${p.key.name}`)
+    if (placement <= seen) return false
+    seen = placement
+  }
+  return true
+}
+
+// Top-level is always relocatable here (hasKnownShape ⇒ no top-level spread). The only blocker is a
+// `run`/`enabled` we must emit verbatim (it holds a spread/unknown nested key) whose own nested keys are
+// out of order — we can't reorder across a spread, so that violation can't be fixed without changing
+// semantics. In that case we report without a fix rather than apply a non-converging partial fix.
+const isFullyFixable = (config: Node.ObjectExpression) =>
+  config.properties.every((prop) => {
+    if (!isPlainProp(prop) || !isRunGroup(prop.key.name) || prop.value.type !== NodeType.ObjectExpression) return true
+    return isReconstructable(prop.value) || isNestedOrdered(prop.key.name, prop.value)
+  })
+
+const currentKeys = (properties: TopProperty[]) => {
+  const keys = new Map<string, true>()
 
   for (const prop of properties) {
     if (prop.value.type !== NodeType.ObjectExpression) {
-      nodes.set(prop.key.name, prop)
+      keys.set(prop.key.name, true)
       continue
     }
 
     for (const p of prop.value.properties) {
-      if (p.type === NodeType.Property && p.key.type === NodeType.Identifier) {
-        const key = `${prop.key.name}.${p.key.name}`
-        nodes.set(key, p)
-      }
+      if (isPlainProp(p)) keys.set(`${prop.key.name}.${p.key.name}`, true)
     }
   }
 
-  return { keys: Array.from(nodes.keys()), nodes }
+  return [...keys.keys()]
 }
 
 const isCorrectOrder = (current: string[]) => {
   let seen = -1
 
   for (const item of current) {
-    const index = TRUE_ORDER.indexOf(item)
-    const placement = index === -1 ? Infinity : index
+    const placement = rankOf(item)
     if (placement <= seen) return false
     seen = placement
   }
@@ -103,24 +157,25 @@ const isCorrectOrder = (current: string[]) => {
   return true
 }
 
-type BuildSnippetsParams = {
-  nodes: Map<string, Node.Property>
-  source: Readonly<TSESLint.SourceCode>
+// Text for one top-level property in the reordered config: a rebuildable `run`/`enabled` is normalized
+// into canonical nested order; everything else (name, shorthand, spread-holding objects) is emitted
+// verbatim so nothing is lost.
+const propText = (prop: TopProperty, source: Readonly<TSESLint.SourceCode>) => {
+  if (isRunGroup(prop.key.name) && prop.value.type === NodeType.ObjectExpression && isReconstructable(prop.value)) {
+    const obj = prop.value
+    const parts = NESTED_ORDER.flatMap((nested) => {
+      const node = obj.properties.find((p): p is TopProperty => isPlainProp(p) && p.key.name === nested)
+      return node ? [`${nested}: ${source.getText(node.value)}`] : []
+    })
+    if (parts.length) return `${prop.key.name}: { ${parts.join(", ")} }`
+  }
+
+  return source.getText(prop)
 }
 
-const buildSnippets = ({ nodes, source }: BuildSnippetsParams) =>
-  GROUPS.map((group) => {
-    if (group.nested) {
-      const parts = group.nested
-        .map((nested) => {
-          const node = nodes.get(`${group.key}.${nested}`)
-          return node ? `${nested}: ${source.getText(node.value)}` : null
-        })
-        .filter(Boolean)
+const reorder = (config: Node.ObjectExpression, source: Readonly<TSESLint.SourceCode>) => {
+  const properties = config.properties as TopProperty[]
+  const ordered = [...properties].sort((a, b) => rankOf(a.key.name) - rankOf(b.key.name))
 
-      return parts.length ? `${group.key}: { ${parts.join(", ")} }` : null
-    }
-
-    const node = nodes.get(group.key)
-    return node ? `${group.key}: ${source.getText(node.value)}` : null
-  }).filter(Boolean)
+  return `{\n${ordered.map((prop) => propText(prop, source)).join(",\n")}\n}`
+}

--- a/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
+++ b/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
@@ -8,24 +8,24 @@ const GROUPS = [
   { key: "enabled", nested: ["context", "fn"] } as const,
 ]
 
-// Canonical rank of every key — top-level groups and their nested keys. A `run`/`enabled` that is
-// opaque (shorthand, variable, …) ranks at its group position; an inline one ranks at the leaf level.
-// A config holds one or the other, never both, so the two never collide.
-const RANK = new Map<string, number>()
-GROUPS.forEach((group, groupIndex) => {
-  RANK.set(group.key, groupIndex * 10)
-  group.nested?.forEach((nested, nestedIndex) => RANK.set(`${group.key}.${nested}`, groupIndex * 10 + nestedIndex + 1))
-})
+// Canonical key order: each group key, immediately followed by its nested keys. A `run`/`enabled`
+// ranks at its group slot when opaque (shorthand, variable, …) and at the leaf slots when inline;
+// a config holds one form or the other, so the two never collide.
+const CANONICAL_KEYS = GROUPS.flatMap((group) => [group.key, ...(group.nested ?? []).map((n) => `${group.key}.${n}`)])
+const RANK = new Map(CANONICAL_KEYS.map((key, index): [string, number] => [key, index]))
 const rankOf = (key: string) => RANK.get(key) ?? Infinity
 
 const TOP_KEYS = new Set<string>(GROUPS.map((group) => group.key))
-const NESTED_KEYS = new Set<string>(GROUPS.flatMap((group) => group.nested ?? []))
 const NESTED_ORDER = GROUPS.find((group) => group.nested)?.nested ?? []
+const NESTED_KEYS = new Set<string>(NESTED_ORDER)
 
 const importSelector = `ImportDeclaration[source.value=${PACKAGE_NAME.CORE}]`
 const methodSelector = `ImportSpecifier[imported.name=${UNITS.CREATE_TASK}]`
 
 const callSelector = `[callee.type="Identifier"][arguments.length=1]`
+// Direct child, not a descendant: matches `createTask({ … })` but not `createTask(factory({ … }))`,
+// where the object literal sits inside a nested call's arguments rather than createTask's own.
+const argumentSelector = `ObjectExpression.arguments`
 
 export default createRule({
   name: "task-options-order",
@@ -46,23 +46,24 @@ export default createRule({
     const source = context.sourceCode
     const imports = new Set<string>()
 
-    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.CallExpressionArgument] }
+    // The selector guarantees a single object-literal argument, so `config` is an ObjectExpression.
+    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.ObjectExpression] }
 
     return {
       [`${importSelector} > ${methodSelector}`]: (node: Node.ImportSpecifier) => void imports.add(node.local.name),
 
-      [`CallExpression${callSelector}`]: (node: MethodCall) => {
+      [`CallExpression${callSelector}:has(> ${argumentSelector})`]: (node: MethodCall) => {
         if (!imports.has(node.callee.name)) return
 
         const [config] = node.arguments
-        // Bail only when the order is genuinely undeterminable (non-object arg, or a top-level spread /
-        // computed / getter / unknown key — anything that hides where the real options sit).
-        if (config.type !== NodeType.ObjectExpression || !hasKnownShape(config)) return
+        // Bail when the order is undeterminable: a top-level spread / computed / getter / unknown key
+        // hides where the real options sit.
+        if (!hasKnownShape(config)) return
 
         const keys = currentKeys(config.properties as TopProperty[])
         if (isCorrectOrder(keys)) return
 
-        const correctOrder = [...keys].sort((a, b) => rankOf(a) - rankOf(b)).join(" -> ")
+        const correctOrder = keys.toSorted((a, b) => rankOf(a) - rankOf(b)).join(" -> ")
         const data = { correctOrder, currentOrder: keys.join(" -> ") }
 
         // Reorder by relocating the real property nodes, so shorthand/spread/comments survive. Attach the
@@ -129,20 +130,20 @@ const isFullyFixable = (config: Node.ObjectExpression) =>
   })
 
 const currentKeys = (properties: TopProperty[]) => {
-  const keys = new Map<string, true>()
+  const keys = new Set<string>()
 
   for (const prop of properties) {
     if (prop.value.type !== NodeType.ObjectExpression) {
-      keys.set(prop.key.name, true)
+      keys.add(prop.key.name)
       continue
     }
 
     for (const p of prop.value.properties) {
-      if (isPlainProp(p)) keys.set(`${prop.key.name}.${p.key.name}`, true)
+      if (isPlainProp(p)) keys.add(`${prop.key.name}.${p.key.name}`)
     }
   }
 
-  return [...keys.keys()]
+  return [...keys]
 }
 
 const isCorrectOrder = (current: string[]) => {
@@ -175,7 +176,7 @@ const propText = (prop: TopProperty, source: Readonly<TSESLint.SourceCode>) => {
 
 const reorder = (config: Node.ObjectExpression, source: Readonly<TSESLint.SourceCode>) => {
   const properties = config.properties as TopProperty[]
-  const ordered = [...properties].sort((a, b) => rankOf(a.key.name) - rankOf(b.key.name))
+  const ordered = properties.toSorted((a, b) => rankOf(a.key.name) - rankOf(b.key.name))
 
   return `{\n${ordered.map((prop) => propText(prop, source)).join(",\n")}\n}`
 }

--- a/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
+++ b/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
@@ -116,13 +116,19 @@ const isOrdered = (keys: string[]) => {
 // at the head (-Infinity) or tail (Infinity); an unknown key sorts to the end (Infinity); an inline
 // `run`/`enabled` is rebuilt recursively (null if its own keys would cross a spread); the rest is
 // emitted verbatim, so shorthand and comments survive.
-const entryOf = (
-  prop: Element,
-  index: number,
-  props: Element[],
-  group: string | null,
-  source: Readonly<TSESLint.SourceCode>,
-): Entry | null => {
+const entryOf = ({
+  prop,
+  index,
+  props,
+  group,
+  source,
+}: {
+  prop: Element
+  index: number
+  props: Element[]
+  group: string | null
+  source: Readonly<TSESLint.SourceCode>
+}): Entry | null => {
   if (isSpread(prop)) {
     if (isTrailingSpread(props, index)) return { rank: Infinity, text: source.getText(prop) }
     if (isLeadingSpread(props, index)) return { rank: -Infinity, text: source.getText(prop) }
@@ -149,7 +155,7 @@ const rebuild = (
 ): string | null => {
   const entries: Entry[] = []
   for (const [index, prop] of obj.properties.entries()) {
-    const entry = entryOf(prop, index, obj.properties, group, source)
+    const entry = entryOf({ prop, index, props: obj.properties, group, source })
     if (entry === null) return null
     entries.push(entry)
   }

--- a/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
+++ b/packages/eslint-plugin/src/rules/task-options-order/task-options-order.ts
@@ -1,23 +1,19 @@
 import { type TSESTree as Node, AST_NODE_TYPES as NodeType, type TSESLint } from "@typescript-eslint/utils"
+import { isPlainProp, isSpread } from "@/shared/ast"
 import { PACKAGE_NAME, UNITS } from "@/shared/constants"
 import { createRule } from "@/shared/create"
 
-const GROUPS = [
-  { key: "name" },
-  { key: "run", nested: ["context", "fn"] } as const,
-  { key: "enabled", nested: ["context", "fn"] } as const,
-]
-
-// Canonical key order: each group key, immediately followed by its nested keys. A `run`/`enabled`
-// ranks at its group slot when opaque (shorthand, variable, …) and at the leaf slots when inline;
-// a config holds one form or the other, so the two never collide.
-const CANONICAL_KEYS = GROUPS.flatMap((group) => [group.key, ...(group.nested ?? []).map((n) => `${group.key}.${n}`)])
-const RANK = new Map(CANONICAL_KEYS.map((key, index): [string, number] => [key, index]))
-const rankOf = (key: string) => RANK.get(key) ?? Infinity
-
-const TOP_KEYS = new Set<string>(GROUPS.map((group) => group.key))
-const NESTED_ORDER = GROUPS.find((group) => group.nested)?.nested ?? []
-const NESTED_KEYS = new Set<string>(NESTED_ORDER)
+// Canonical key order, flat: every option, top-level groups and their nested keys, in one list. A
+// `run`/`enabled` ranks at its group slot when opaque (shorthand, variable, …) and at its leaf slots
+// when inline; a config holds one form or the other, so the two never collide.
+const ORDER = ["name", "run", "run.context", "run.fn", "enabled", "enabled.context", "enabled.fn"]
+const rankOf = (key: string) => {
+  const index = ORDER.indexOf(key)
+  return index === -1 ? Infinity : index
+}
+// `run`/`enabled` carry nested keys; `name` does not. An inline group is rebuilt from its leaves, an
+// opaque one (shorthand, variable) ranks at its group slot and stays whole.
+const hasNested = (key: string) => ORDER.some((entry) => entry.startsWith(`${key}.`))
 
 const importSelector = `ImportDeclaration[source.value=${PACKAGE_NAME.CORE}]`
 const methodSelector = `ImportSpecifier[imported.name=${UNITS.CREATE_TASK}]`
@@ -56,127 +52,108 @@ export default createRule({
         if (!imports.has(node.callee.name)) return
 
         const [config] = node.arguments
-        // Bail when the order is undeterminable: a top-level spread / computed / getter / unknown key
-        // hides where the real options sit.
-        if (!hasKnownShape(config)) return
+        // The order is undeterminable when a spread sits between options (it could inject any key) or
+        // an exotic entry (computed key, getter, method) hides a name — so we don't report. Unknown
+        // plain keys are fine: they just sort to the end.
+        if (!isReorderable(config)) return
 
-        const keys = currentKeys(config.properties as TopProperty[])
-        if (isCorrectOrder(keys)) return
+        const keys = orderKeys(config)
+        if (isOrdered(keys)) return
 
-        const correctOrder = keys.toSorted((a, b) => rankOf(a) - rankOf(b)).join(" -> ")
-        const data = { correctOrder, currentOrder: keys.join(" -> ") }
-
-        // Reorder by relocating the real property nodes, so shorthand/spread/comments survive. Attach the
-        // fix only when it fully resolves the violation; if a nested key would have to move across a spread
-        // (where position is semantically load-bearing), report it but leave the code for a human.
-        if (isFullyFixable(config)) {
-          context.report({
-            node: config,
-            messageId: "invalidOrder",
-            data,
-            fix: (fixer) => [fixer.replaceText(config, reorder(config, source))],
-          })
-          return
+        const data = {
+          correctOrder: keys.toSorted((a, b) => rankOf(a) - rankOf(b)).join(" -> "),
+          currentOrder: keys.join(" -> "),
         }
 
-        context.report({ node: config, messageId: "invalidOrder", data })
+        // One pass relocates the real nodes, so shorthand/spread/comments survive. `rebuild` returns
+        // null when a nested key would have to cross a spread (position is load-bearing there): we
+        // report the violation but leave the fix to a human.
+        const fixed = rebuild(config, null, source)
+        context.report({
+          node: config,
+          messageId: "invalidOrder",
+          data,
+          fix: fixed === null ? undefined : (fixer) => fixer.replaceText(config, fixed),
+        })
       },
     }
   },
 })
 
-type TopProperty = Node.Property & { key: Node.Identifier }
+type Element = Node.ObjectExpression["properties"][number]
+type Entry = { rank: number; text: string }
 
-// A plain `key: value` (or shorthand) property — the only shape we relocate/rebuild by name.
-// Spreads, getters/setters, methods and computed keys are not plain props.
-const isPlainProp = (prop: Node.ObjectLiteralElement): prop is Node.Property & { key: Node.Identifier } =>
-  prop.type === NodeType.Property &&
-  prop.kind === "init" &&
-  !prop.method &&
-  !prop.computed &&
-  prop.key.type === NodeType.Identifier
+// A spread anchors a boundary — keys never cross it — so it only fits at the head or tail of a config.
+const isLeadingSpread = (props: Element[], index: number) => props.slice(0, index).every(isSpread)
+const isTrailingSpread = (props: Element[], index: number) => props.slice(index + 1).every(isSpread)
 
-// The order is determinable when every top-level entry is a plain, known key. A spread / computed /
-// getter / unknown key hides where the real options sit, so we can't reason about order at all.
-const hasKnownShape = (config: Node.ObjectExpression) =>
-  config.properties.every((prop) => isPlainProp(prop) && TOP_KEYS.has(prop.key.name))
+// Can we reason about the top-level order? Every entry must be a plain key (known or unknown) or a
+// spread anchored at the head/tail. An interior spread or an exotic entry hides where options sit.
+const isReorderable = (config: Node.ObjectExpression) =>
+  config.properties.every((prop, index, props) =>
+    isSpread(prop) ? isLeadingSpread(props, index) || isTrailingSpread(props, index) : isPlainProp(prop),
+  )
 
-const isRunGroup = (name: string) => name === "run" || name === "enabled"
+// The visible dotted keys in source order, for the message and the ordered check. A `run`/`enabled`
+// object expands into its nested keys; every other plain key contributes its own; spreads carry none.
+const orderKeys = (config: Node.ObjectExpression): string[] =>
+  config.properties.flatMap((prop) =>
+    !isPlainProp(prop)
+      ? []
+      : prop.value.type === NodeType.ObjectExpression
+        ? prop.value.properties.filter(isPlainProp).map((nested) => `${prop.key.name}.${nested.key.name}`)
+        : [prop.key.name],
+  )
 
-// A `run`/`enabled` object we can rebuild key-by-key: only plain, known nested keys (no spread/unknown).
-const isReconstructable = (obj: Node.ObjectExpression) =>
-  obj.properties.every((p) => isPlainProp(p) && NESTED_KEYS.has(p.key.name))
-
-// Are the visible nested keys already in canonical order? (Used for objects we can't rebuild.)
-const isNestedOrdered = (group: string, obj: Node.ObjectExpression) => {
-  let seen = -1
-  for (const p of obj.properties) {
-    if (!isPlainProp(p) || !NESTED_KEYS.has(p.key.name)) continue
-    const placement = rankOf(`${group}.${p.key.name}`)
-    if (placement <= seen) return false
-    seen = placement
-  }
-  return true
+// Already canonical? A stable sort leaves equal ranks (unknown keys, multiple spreads) in place, so an
+// ordered config sorts to itself.
+const isOrdered = (keys: string[]) => {
+  const sorted = keys.toSorted((a, b) => rankOf(a) - rankOf(b))
+  return keys.every((key, index) => key === sorted[index])
 }
 
-// Top-level is always relocatable here (hasKnownShape ⇒ no top-level spread). The only blocker is a
-// `run`/`enabled` we must emit verbatim (it holds a spread/unknown nested key) whose own nested keys are
-// out of order — we can't reorder across a spread, so that violation can't be fixed without changing
-// semantics. In that case we report without a fix rather than apply a non-converging partial fix.
-const isFullyFixable = (config: Node.ObjectExpression) =>
-  config.properties.every((prop) => {
-    if (!isPlainProp(prop) || !isRunGroup(prop.key.name) || prop.value.type !== NodeType.ObjectExpression) return true
-    return isReconstructable(prop.value) || isNestedOrdered(prop.key.name, prop.value)
-  })
+// Sort rank and source text for one entry, or null when it can't be reordered safely. A spread anchors
+// at the head (-Infinity) or tail (Infinity); an unknown key sorts to the end (Infinity); an inline
+// `run`/`enabled` is rebuilt recursively (null if its own keys would cross a spread); the rest is
+// emitted verbatim, so shorthand and comments survive.
+const entryOf = (
+  prop: Element,
+  index: number,
+  props: Element[],
+  group: string | null,
+  source: Readonly<TSESLint.SourceCode>,
+): Entry | null => {
+  if (isSpread(prop)) {
+    if (isTrailingSpread(props, index)) return { rank: Infinity, text: source.getText(prop) }
+    if (isLeadingSpread(props, index)) return { rank: -Infinity, text: source.getText(prop) }
+    return null
+  }
+  if (!isPlainProp(prop)) return null
 
-const currentKeys = (properties: TopProperty[]) => {
-  const keys = new Set<string>()
+  const key = group === null ? prop.key.name : `${group}.${prop.key.name}`
 
-  for (const prop of properties) {
-    if (prop.value.type !== NodeType.ObjectExpression) {
-      keys.add(prop.key.name)
-      continue
-    }
-
-    for (const p of prop.value.properties) {
-      if (isPlainProp(p)) keys.add(`${prop.key.name}.${p.key.name}`)
-    }
+  if (group === null && hasNested(prop.key.name) && prop.value.type === NodeType.ObjectExpression) {
+    const inner = rebuild(prop.value, prop.key.name, source)
+    return inner === null ? null : { rank: rankOf(key), text: `${prop.key.name}: ${inner}` }
   }
 
-  return [...keys]
+  return { rank: rankOf(key), text: source.getText(prop) }
 }
 
-const isCorrectOrder = (current: string[]) => {
-  let seen = -1
-
-  for (const item of current) {
-    const placement = rankOf(item)
-    if (placement <= seen) return false
-    seen = placement
+// Canonical source text for an object literal, or null when an entry can't be reordered safely. The top
+// level (group null) prints one entry per line; a nested `run`/`enabled` stays inline.
+const rebuild = (
+  obj: Node.ObjectExpression,
+  group: string | null,
+  source: Readonly<TSESLint.SourceCode>,
+): string | null => {
+  const entries: Entry[] = []
+  for (const [index, prop] of obj.properties.entries()) {
+    const entry = entryOf(prop, index, obj.properties, group, source)
+    if (entry === null) return null
+    entries.push(entry)
   }
 
-  return true
-}
-
-// Text for one top-level property in the reordered config: a rebuildable `run`/`enabled` is normalized
-// into canonical nested order; everything else (name, shorthand, spread-holding objects) is emitted
-// verbatim so nothing is lost.
-const propText = (prop: TopProperty, source: Readonly<TSESLint.SourceCode>) => {
-  if (isRunGroup(prop.key.name) && prop.value.type === NodeType.ObjectExpression && isReconstructable(prop.value)) {
-    const obj = prop.value
-    const parts = NESTED_ORDER.flatMap((nested) => {
-      const node = obj.properties.find((p): p is TopProperty => isPlainProp(p) && p.key.name === nested)
-      return node ? [`${nested}: ${source.getText(node.value)}`] : []
-    })
-    if (parts.length) return `${prop.key.name}: { ${parts.join(", ")} }`
-  }
-
-  return source.getText(prop)
-}
-
-const reorder = (config: Node.ObjectExpression, source: Readonly<TSESLint.SourceCode>) => {
-  const properties = config.properties as TopProperty[]
-  const ordered = properties.toSorted((a, b) => rankOf(a.key.name) - rankOf(b.key.name))
-
-  return `{\n${ordered.map((prop) => propText(prop, source)).join(",\n")}\n}`
+  const texts = entries.toSorted((a, b) => a.rank - b.rank).map((entry) => entry.text)
+  return group === null ? `{\n${texts.join(",\n")}\n}` : `{ ${texts.join(", ")} }`
 }

--- a/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.test.ts
+++ b/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.test.ts
@@ -29,6 +29,15 @@ ruleTester.run("wire-options-order", rule, {
         createWire({ from: literal("https://api.example.com") })
       `,
     },
+    {
+      name: "argument is a factory call, not an object literal",
+      code: ts`
+        ${commonCode}
+
+        declare const buildWire: (opts: Parameters<typeof createWire>[0]) => Parameters<typeof createWire>[0];
+        createWire(buildWire({ to: apiUrl, from: literal("https://api.example.com"), }))
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.test.ts
+++ b/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.test.ts
@@ -38,6 +38,15 @@ ruleTester.run("wire-options-order", rule, {
         createWire(buildWire({ to: apiUrl, from: literal("https://api.example.com"), }))
       `,
     },
+    {
+      name: "leading spread — shape undeterminable, left untouched",
+      code: ts`
+        ${commonCode}
+
+        declare const rest: Parameters<typeof createWire>[0];
+        createWire({ ...rest, to: apiUrl })
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.ts
+++ b/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.ts
@@ -5,6 +5,10 @@ import { createRule } from "@/shared/create"
 const importSelector = `ImportDeclaration[source.value=${PACKAGE_NAME.CORE}]`
 const methodSelector = `ImportSpecifier[imported.name=${UNITS.CREATE_WIRE}]`
 const callSelector = `[callee.type="Identifier"][arguments.length=1]`
+// Direct child, not a descendant: matches `createWire({ … })` but not `createWire(buildWire({ … }))`,
+// where the object literal sits inside a nested call. The two-property count is a cheap structural
+// predicate, so it rides along in the selector; the shape of those two entries is narrowed in the body.
+const argumentSelector = `ObjectExpression.arguments[properties.length=2]`
 
 export default createRule({
   name: "wire-options-order",
@@ -25,19 +29,19 @@ export default createRule({
     const source = context.sourceCode
     const imports = new Set<string>()
 
-    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.CallExpressionArgument] }
+    // The selector guarantees a single object-literal argument with exactly two properties, so
+    // `config` is an ObjectExpression; the shape of those two entries is still narrowed in the body.
+    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.ObjectExpression] }
 
     return {
       [`${importSelector} > ${methodSelector}`]: (node: Node.ImportSpecifier) => void imports.add(node.local.name),
 
-      [`CallExpression${callSelector}`]: (node: MethodCall) => {
+      [`CallExpression${callSelector}:has(> ${argumentSelector})`]: (node: MethodCall) => {
         if (!imports.has(node.callee.name)) return
 
         const [config] = node.arguments
-        if (config.type !== NodeType.ObjectExpression) return
-        if (config.properties.length !== 2) return
-
         const [first, second] = config.properties
+
         if (
           first?.type !== NodeType.Property ||
           first.key.type !== NodeType.Identifier ||

--- a/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.ts
+++ b/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.ts
@@ -5,7 +5,6 @@ import { createRule } from "@/shared/create"
 const importSelector = `ImportDeclaration[source.value=${PACKAGE_NAME.CORE}]`
 const methodSelector = `ImportSpecifier[imported.name=${UNITS.CREATE_WIRE}]`
 const callSelector = `[callee.type="Identifier"][arguments.length=1]`
-const argumentSelector = `ObjectExpression.arguments`
 
 export default createRule({
   name: "wire-options-order",
@@ -26,15 +25,16 @@ export default createRule({
     const source = context.sourceCode
     const imports = new Set<string>()
 
-    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.ObjectExpression] }
+    type MethodCall = Node.CallExpression & { callee: Node.Identifier; arguments: [Node.CallExpressionArgument] }
 
     return {
       [`${importSelector} > ${methodSelector}`]: (node: Node.ImportSpecifier) => void imports.add(node.local.name),
 
-      [`CallExpression${callSelector}:has(${argumentSelector})`]: (node: MethodCall) => {
+      [`CallExpression${callSelector}`]: (node: MethodCall) => {
         if (!imports.has(node.callee.name)) return
 
         const [config] = node.arguments
+        if (config.type !== NodeType.ObjectExpression) return
         if (config.properties.length !== 2) return
 
         const [first, second] = config.properties

--- a/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.ts
+++ b/packages/eslint-plugin/src/rules/wire-options-order/wire-options-order.ts
@@ -1,4 +1,5 @@
-import { AST_NODE_TYPES as NodeType, type TSESTree as Node } from "@typescript-eslint/utils"
+import type { TSESTree as Node } from "@typescript-eslint/utils"
+import { isPlainProp } from "@/shared/ast"
 import { PACKAGE_NAME, UNITS } from "@/shared/constants"
 import { createRule } from "@/shared/create"
 
@@ -42,13 +43,7 @@ export default createRule({
         const [config] = node.arguments
         const [first, second] = config.properties
 
-        if (
-          first?.type !== NodeType.Property ||
-          first.key.type !== NodeType.Identifier ||
-          second?.type !== NodeType.Property ||
-          second.key.type !== NodeType.Identifier
-        )
-          return
+        if (!first || !second || !isPlainProp(first) || !isPlainProp(second)) return
 
         if (first.key.name === "from") return
 

--- a/packages/eslint-plugin/src/shared/ast.ts
+++ b/packages/eslint-plugin/src/shared/ast.ts
@@ -1,0 +1,17 @@
+import { AST_NODE_TYPES as NodeType, ASTUtils, type TSESTree as Node } from "@typescript-eslint/utils"
+import esquery from "esquery"
+
+type KeyedProp = Node.Property & { key: Node.Identifier }
+
+// A plain `key: value` (or shorthand) property — the shape the options-order rules relocate by name.
+// Matched with an esquery selector, like the rules' node matches; the `prop is KeyedProp` annotation
+// keeps `.filter`/`.find` callers narrowed. Spreads, getters/setters, methods and computed keys miss.
+const PLAIN_PROP = esquery.parse(`Property[kind="init"][method=false][computed=false][key.type="Identifier"]`)
+const isPlainProp = (prop: Node.ObjectLiteralElement): prop is KeyedProp =>
+  esquery.matches(prop as unknown as Parameters<typeof esquery.matches>[0], PLAIN_PROP)
+
+// A spread element (`...rest`) inside an object literal. It carries no key of its own, so it anchors a
+// position rather than taking part in key ordering.
+const isSpread = ASTUtils.isNodeOfType(NodeType.SpreadElement)
+
+export { isPlainProp, isSpread }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.60.0
         version: 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      esquery:
+        specifier: ^1.7.0
+        version: 1.7.0
       typescript:
         specifier: ^5.0.0 || ^6.0.0
         version: 6.0.3
@@ -128,6 +131,9 @@ importers:
       '@grlt-hub/app-compose':
         specifier: workspace:*
         version: link:../app-compose
+      '@types/esquery':
+        specifier: 1.5.4
+        version: 1.5.4
       '@typescript-eslint/rule-tester':
         specifier: 8.60.0
         version: 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
@@ -1976,6 +1982,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/esquery@1.5.4':
+    resolution: {integrity: sha512-yYO4Q8H+KJHKW1rEeSzHxcZi90durqYgWVfnh5K6ZADVBjBv2e1NEveYX5yT2bffgN7RqzH3k9930m+i2yBoMA==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -5729,6 +5738,10 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/esquery@1.5.4':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/esrecurse@4.3.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,6 @@ ignoredBuiltDependencies:
 minimumReleaseAge: 4320
 
 onlyBuiltDependencies:
-  - es5-ext
   - esbuild
   - lefthook
   - workerd

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,5 +12,11 @@ ignoredBuiltDependencies:
 
 minimumReleaseAge: 4320
 
+onlyBuiltDependencies:
+  - es5-ext
+  - esbuild
+  - lefthook
+  - workerd
+
 patchedDependencies:
   starlight-llms-txt: patches/starlight-llms-txt.patch


### PR DESCRIPTION
## What

For a `Task` target, `debug` built its `output` spot as:

```ts
shape(
  { status: optional(target.status), result: optional(target.result), error: optional(target.error) },
  (x) => x,
)
```

This drops the trailing `(x) => x`, using the single-arg `shape(ctx)` overload instead.

## Why

The identity `fn` is dead weight:

- **Runtime** — every field is wrapped in `optional()`, so each leaf resolves to a value or `undefined`, never `Missing$`. The assembled object is therefore never `Missing$`, and `safe(identity)` just returns it unchanged. The output is byte-identical with or without the `fn`; the only effect was one extra `safe()`-wrapped identity step pushed onto the spot's compute pipeline per debug run.
- **Types** — the single-arg overload `shape<T>(ctx): Spot<T>` infers the same `Spot<{ status, result, error }>`. The identity adds no type information.

The trailing `(x) => x` predates the single-arg `shape` overload — leftover plumbing from when a `fn` was required.

## Verification

- `pnpm --filter ./packages/app-coda test` — 142 passed, no type errors (debug snapshot tests confirm output is unchanged)
- `pnpm --filter ./packages/app-coda build` — clean, declarations emit unchanged

## Linter fixes (eslint-plugin)

Hardened `task-options-order` and `wire-options-order` while on this branch. Both rules matched call sites with a `:has(ObjectExpression.arguments)` filter and assumed the argument was always an object literal — which was unsound. Defects fixed:

- **Crash on wrapped arguments** — `createTask(factory({...}))` (and `createWire(buildWire({...}))`) made the rule operate on a non-object node; `task` threw calling `.some()` on it. Both rules now bail unless the argument is an object literal (`config.type !== ObjectExpression`).
- **Autofix dropped code** — the task autofix rebuilt the config from a fixed schema and silently dropped shorthand `run`/`enabled`, dropped unknown top-level keys, and emitted invalid syntax for getters. It now relocates the real property nodes, so shorthand, spreads, and unknown props survive verbatim.
- **Non-converging autofix** — when a nested key would have to move across a spread, the rule now reports without attaching a fix instead of applying one that can't converge.

Verification: `pnpm --filter ./packages/eslint-plugin test` — 38 passed; build (`tsc --noEmit` + `tsdown`), `knip`, and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
