### PR TITLE
docs: agent-readiness follow-ups — page-aware JSON-LD + trailing-slash redirects

### DIFF
--- a/documentation/astro.config.mjs
+++ b/documentation/astro.config.mjs
@@ -164,8 +164,8 @@ export default defineConfig({
     }),
   ],
   redirects: {
-    "/app-compose/tutorials/getting-started": "/learn/quick-start",
+    "/app-compose/tutorials/getting-started": "/learn/quick-start/",
     "/app-compose/tutorials/dependencies": "/learn/quick-start/#how-to-pass-data-to-a-task",
-    "/guides/sharing-tags": "/guides/managing-tags",
+    "/guides/sharing-tags": "/guides/managing-tags/",
   },
 })

--- a/documentation/src/components/Head.astro
+++ b/documentation/src/components/Head.astro
@@ -1,17 +1,81 @@
 ---
 import Default from "@astrojs/starlight/components/Head.astro"
 
-// Declare the merged "appcompose" spelling as a brand synonym for search engines.
-const schema = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: "App-Compose",
-  alternateName: ["appcompose", "app compose"],
-  applicationCategory: "DeveloperApplication",
-  operatingSystem: "Web",
-  url: "https://app-compose.dev",
-  description: "Lightweight IoC for the front-end. Compose apps you can control and trust.",
+const SITE = "https://app-compose.dev"
+const ORG_ID = "https://github.com/grlt-hub"
+const WEBSITE_ID = `${SITE}/#website`
+const TAGLINE = "Lightweight IoC for the front-end. Compose apps you can control and trust."
+
+// grlt-hub as the publishing entity; `withId` defines the node once so other nodes can reference it.
+const org = (withId) => ({ "@type": "Organization", ...(withId && { "@id": ORG_ID }), name: "grlt-hub", url: ORG_ID })
+
+const route = Astro.locals.starlightRoute
+const pathname = Astro.url.pathname
+const canonical = new URL(pathname, Astro.site).href
+const isHome = pathname === "/"
+
+// Walk the sidebar to the current page, keeping the groups passed through on the way.
+const findTrail = (entries, trail) => {
+  for (const entry of entries) {
+    if (entry.type === "group") {
+      const found = findTrail(entry.entries, [...trail, entry])
+      if (found) return found
+    } else if (entry.isCurrent) {
+      return [...trail, entry]
+    }
+  }
+  return null
 }
+
+const breadcrumb = () => {
+  const items = [{ name: "Home", url: `${SITE}/` }]
+  const group = findTrail(route.sidebar, [])?.find((entry) => entry.type === "group")
+  const segment = pathname.split("/").filter(Boolean)[0]
+  // Only add a section crumb when that section has its own index page, and it is not the current page.
+  const section = group?.entries.find((entry) => entry.type === "link" && entry.href === `/${segment}/`)
+  const sectionUrl = section && new URL(section.href, Astro.site).href
+  if (sectionUrl && sectionUrl !== canonical) items.push({ name: group.label, url: sectionUrl })
+  items.push({ name: route.entry.data.title, url: canonical })
+
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({ "@type": "ListItem", position: index + 1, name: item.name, item: item.url })),
+  }
+}
+
+const graph = isHome
+  ? [
+      org(true),
+      { "@type": "WebSite", "@id": WEBSITE_ID, name: "App-Compose", url: SITE, description: TAGLINE, inLanguage: "en", publisher: { "@id": ORG_ID } },
+      {
+        "@type": "SoftwareApplication",
+        name: "App-Compose",
+        alternateName: ["appcompose", "app compose"],
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Web",
+        url: SITE,
+        description: TAGLINE,
+        author: { "@id": ORG_ID },
+        sameAs: ["https://github.com/grlt-hub/app-compose", "https://www.npmjs.com/package/@grlt-hub/app-compose"],
+      },
+    ]
+  : [
+      {
+        "@type": "TechArticle",
+        "@id": `${canonical}#article`,
+        headline: route.entry.data.title,
+        description: route.entry.data.description,
+        url: canonical,
+        inLanguage: "en",
+        isPartOf: { "@id": WEBSITE_ID },
+        author: org(false),
+        publisher: org(false),
+        ...(route.lastUpdated && { dateModified: route.lastUpdated.toISOString() }),
+      },
+      breadcrumb(),
+    ]
+
+const schema = { "@context": "https://schema.org", "@graph": graph }
 ---
 
 <Default />


### PR DESCRIPTION
From the agent-readiness audit of app-compose.dev. Two repo-side changes; the Link-header / content-type fixes from the same audit were applied at the Cloudflare edge separately.

## feat(docs): page-aware JSON-LD
`Head.astro` previously emitted one static `SoftwareApplication` block, identical on all 39 pages. Now the structured data matches each page:
- **Homepage** — `Organization` (grlt-hub) + `WebSite` + `SoftwareApplication`, keeping the `appcompose` brand synonym and adding `author` + `sameAs` (GitHub, npm).
- **Content pages** — `TechArticle` (title, description, `dateModified` from git `lastUpdated`) + `BreadcrumbList` derived from the sidebar.
- Redirect stubs stay markup-free (`noindex`). All 41 built pages verified to emit valid JSON-LD, pre-rendered in HTML.

## fix(docs): trailing-slash redirect targets
Redirect targets now use the canonical slashed form, so the generated meta-refresh stub links straight to the final URL — removes the extra trailing-slash normalization hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)