### PR TITLE
feat(docs): add og.png as article image in JSON-LD

### DIFF
--- a/documentation/src/components/Head.astro
+++ b/documentation/src/components/Head.astro
@@ -66,6 +66,7 @@ const graph = isHome
         headline: route.entry.data.title,
         description: route.entry.data.description,
         url: canonical,
+        image: `${SITE}/og.png`,
         inLanguage: "en",
         isPartOf: { "@id": WEBSITE_ID },
         author: org(false),


### PR DESCRIPTION
Follow-up to the agent-readiness JSON-LD work. Google's Rich Results Test flagged a non-critical *Missing field "image" (optional)* on article pages.

Adds `image` to each `TechArticle`, pointing at the existing site share image `og.png` (1200×630). Clears the optional-image note and makes article pages eligible for image-bearing rich results. One field; homepage and breadcrumb markup unchanged. Verified locally that all built pages still emit valid JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)