### PR TITLE
perf: use tsgo for typechecking in build and vitest

### DIFF
--- a/packages/coda/knip.json
+++ b/packages/coda/knip.json
@@ -2,6 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignore": ["**/__tests__/**", "*.config.ts"],
   "entry": ["./src/index.ts!"],
-  "ignoreBinaries": ["tsdown", "knip", "oxlint", "vitest", "tsc"],
+  "ignoreBinaries": ["tsdown", "knip", "oxlint", "vitest", "tsgo"],
   "vitest": { "config": "vitest.config.ts", "entry": "src/**/*.{test,test-d,bench}.ts" }
 }

--- a/packages/coda/package.json
+++ b/packages/coda/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --noEmit -p tsconfig.json && tsdown",
+    "build": "tsgo --noEmit -p tsconfig.json && tsdown",
     "dev": "tsdown --watch",
     "prepack": "pnpm build",
     "bench": "vitest bench",

--- a/packages/coda/vitest.config.ts
+++ b/packages/coda/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
-    typecheck: { enabled: true },
+    typecheck: { enabled: true, checker: "tsgo" },
     restoreMocks: true,
   },
 })

--- a/packages/core/knip.json
+++ b/packages/core/knip.json
@@ -2,6 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignore": ["**/__tests__/**", "*.config.ts"],
   "entry": ["./src/index.ts!"],
-  "ignoreBinaries": ["tsdown", "knip", "oxlint", "vitest", "tsc"],
+  "ignoreBinaries": ["tsdown", "knip", "oxlint", "vitest", "tsgo"],
   "vitest": { "config": "vitest.config.ts", "entry": "src/**/*.{test,test-d,bench}.ts" }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --noEmit -p tsconfig.json && tsdown",
+    "build": "tsgo --noEmit -p tsconfig.json && tsdown",
     "dev": "tsdown --watch",
     "prepack": "pnpm build",
     "bench": "vitest bench",

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
-    typecheck: { enabled: true },
+    typecheck: { enabled: true, checker: "tsgo" },
   },
 
   resolve: {

--- a/packages/eslint-plugin/knip.json
+++ b/packages/eslint-plugin/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignore": ["*.config.ts"],
   "entry": ["./src/index.ts!"],
-  "ignoreBinaries": ["tsdown", "knip", "oxlint", "vitest"],
+  "ignoreBinaries": ["tsdown", "knip", "oxlint", "vitest", "tsgo"],
   "ignoreDependencies": ["@app-compose/coda", "@app-compose/core", "vitest"],
   "vitest": { "config": "vitest.config.ts", "entry": "src/**/*.test.ts" }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --noEmit -p tsconfig.json && tsdown",
+    "build": "tsgo --noEmit -p tsconfig.json && tsdown",
     "dev": "tsdown --watch",
     "prepack": "pnpm build",
     "test": "vitest run",


### PR DESCRIPTION
Swap tsc -> tsgo (@typescript/native-preview) for the --noEmit typecheck step in all package build scripts and as vitest's typecheck.checker.

~45% faster typecheck and ~27% faster full build per package; vitest typecheck phase ~210ms -> ~70ms. All test suites still pass and the checker still reports type errors.